### PR TITLE
power: Remove POWER_HINT_AUDIO

### DIFF
--- a/power/power.c
+++ b/power/power.c
@@ -80,8 +80,7 @@ static void power_hint(struct power_module *module, power_hint_t hint,
         case POWER_HINT_VSYNC:
         case POWER_HINT_INTERACTION:
         case POWER_HINT_CPU_BOOST:
-        case POWER_HINT_LAUNCH_BOOST:
-        case POWER_HINT_AUDIO:
+        case POWER_HINT_LAUNCH:
         case POWER_HINT_SET_PROFILE:
         case POWER_HINT_VIDEO_ENCODE:
         case POWER_HINT_VIDEO_DECODE:


### PR DESCRIPTION
power: Use POWER_HINT_LAUNCH for launch boosts
AOSP introduced POWER_HINT_LAUNCH in 7.1 to indicate the start-up of a new activity. Use it.